### PR TITLE
Feature: Add support for canvas

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -64,15 +64,19 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
           (raw) => {
             if (file.stat.size === 0) return [];
 
-            const data = JSON.parse(raw);
-            return data["nodes"]
-              .filter(
-                // Filter out non-markdown files
-                (node: CanvasNode) =>
-                  node.type === "file" && !node.file.endsWith(".md"),
-              )
-              .map((node: CanvasNode) => node.file)
-              .reduce((prev: [], cur: []) => [...prev, cur], []);
+            try {
+              const data = JSON.parse(raw);
+              return data["nodes"]
+                .filter(
+                  // Filter out non-markdown files
+                  (node: CanvasNode) =>
+                    node.type === "file" && !node.file.endsWith(".md"),
+                )
+                .map((node: CanvasNode) => node.file)
+                .reduce((prev: [], cur: []) => [...prev, cur], []);
+            } catch (error) {
+              new Notice(`Failed to parse canvas file: ${file.path}`);
+            }
           },
         );
       }),

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,7 +54,7 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
     .reduce((prev, cur) => [...prev, ...cur], [])
     .filter((file) => !file.endsWith(".md"));
 
-  const canvasAttachments: string[] = await Promise.all(
+  const canvasAttachmentsInitial: string[] = await Promise.all(
     app.vault
       .getFiles()
       .filter((file) => file.extension == "canvas")
@@ -72,10 +72,15 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
                   node.type === "file" && !node.file.endsWith(".md"),
               )
               .map((node: CanvasNode) => node.file)
-              .reduce((prev: [], cur: []) => [...prev, ...cur]);
+              .reduce((prev: [], cur: []) => [...prev, cur], []);
           },
         );
       }),
+  );
+  // Build up a 1-dimensional array of path strings
+  const canvasAttachments = canvasAttachmentsInitial.reduce(
+    (prev, cur) => [...prev, ...cur],
+    [],
   );
 
   // Get list of all files

--- a/src/util.ts
+++ b/src/util.ts
@@ -62,6 +62,8 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
         return await app.vault.read(file).then(
           // Iterate over found canvas files to fetch the nodes
           (raw) => {
+            if (file.stat.size === 0) return [];
+
             const data = JSON.parse(raw);
             return data["nodes"]
               .filter(

--- a/src/util.ts
+++ b/src/util.ts
@@ -98,7 +98,9 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
     .filter(
       (file) =>
         // Filters any attachment that is not in use
-        !inUseAttachments.includes(file.path) && file,
+        !inUseAttachments.includes(file.path) &&
+        !canvasAttachments.includes(file.path) &&
+        file,
     );
 
   // Run cleanup


### PR DESCRIPTION
Currently canvas files are currently not indexed by Obsidian, this results in attachment being unintentionally removed during cleanup.

This PR fixes this by going through each canvas file fetching the nodes and builds an array of the included attachments.
This array is then used to ignore these files when running the cleanup.