### PR TITLE
Add: Support for cleaning files with only frontmatter

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -31,6 +31,15 @@ const enUS: Locale = {
         Placeholder: "Example: .jpg, .png, .pdf",
       },
 
+      IgnoredFrontmatter: {
+        Label: "Ignored frontmatter",
+        Description: `
+          List of frontmatter properties that should be ignored during cleanup.
+          If a file contains only frontmatter and contains only these properties, the file will be removed, comma-separated.
+        `,
+        Placeholder: "Example:\ncreated, updated",
+      },
+
       PreviewDeletedFiles: {
         Label: "Preview deleted files",
         Description: "Show a confirmation box with list of files to be removed",

--- a/src/locales/locale.d.ts
+++ b/src/locales/locale.d.ts
@@ -24,6 +24,12 @@ export interface Locale {
         Placeholder: string;
       };
 
+      IgnoredFrontmatter: {
+        Label: string;
+        Description: string;
+        Placeholder: string;
+      };
+
       PreviewDeletedFiles: {
         Label: string;
         Description: string;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,6 +11,7 @@ export interface FileCleanerSettings {
   deletionConfirmation: boolean;
   runOnStartup: boolean;
   removeFolders: boolean;
+  ignoredFrontmatter: string[];
 }
 
 export const DEFAULT_SETTINGS: FileCleanerSettings = {
@@ -20,6 +21,7 @@ export const DEFAULT_SETTINGS: FileCleanerSettings = {
   deletionConfirmation: true,
   runOnStartup: false,
   removeFolders: true,
+  ignoredFrontmatter: [],
 };
 
 export class FileCleanerSettingTab extends PluginSettingTab {
@@ -121,6 +123,29 @@ export class FileCleanerSettingTab extends PluginSettingTab {
           translate().Settings.RegularOptions.Attachments.Placeholder,
         );
         text.inputEl.rows = 3;
+        text.inputEl.cols = 30;
+      });
+
+    new Setting(containerEl)
+      .setName(translate().Settings.RegularOptions.IgnoredFrontmatter.Label)
+      .setDesc(
+        translate().Settings.RegularOptions.IgnoredFrontmatter.Description,
+      )
+      .addTextArea((text) => {
+        text
+          .setValue(this.plugin.settings.ignoredFrontmatter.join(", "))
+          .onChange(async (value) => {
+            this.plugin.settings.ignoredFrontmatter = value
+              .split(",")
+              .map((ext) => ext.trim())
+              .filter((ext) => ext.length > 1 && ext !== "");
+
+            this.plugin.saveSettings();
+          });
+        text.setPlaceholder(
+          translate().Settings.RegularOptions.IgnoredFrontmatter.Placeholder,
+        );
+        text.inputEl.rows = 4;
         text.inputEl.cols = 30;
       });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -107,14 +107,15 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
       // Filters out only allowed extensions (including markdowns)
       file.extension.match(allowedExtensions),
     )
+    // Filters out files for further processing
     .filter((file) => {
-      // Filters out any non-markdown files
+      // Filter out all files that are not markdown
       if (file.extension !== "md") return true;
 
       // Filter out any markdown files that are empty including only whitespace
       if (!app.metadataCache.getFileCache(file).sections) return true;
 
-      return false;
+      return false; // Ignore all other files
     })
     .filter(
       (file) =>

--- a/src/util.ts
+++ b/src/util.ts
@@ -111,8 +111,8 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
       // Filters out any non-markdown files
       if (file.extension !== "md") return true;
 
-      // Filters out any markdown file that is empty
-      if (file.stat.size === 0) return true;
+      // Filter out any markdown files that are empty including only whitespace
+      if (!app.metadataCache.getFileCache(file).sections) return true;
 
       return false;
     })

--- a/src/util.ts
+++ b/src/util.ts
@@ -107,12 +107,15 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
       // Filters out only allowed extensions (including markdowns)
       file.extension.match(allowedExtensions),
     )
-    .filter(
-      (file) =>
-        // Filters out any markdown file that is empty
-        (file.extension === "md" && file.stat.size === 0) ||
-        file.extension !== "md",
-    )
+    .filter((file) => {
+      // Filters out any non-markdown files
+      if (file.extension !== "md") return true;
+
+      // Filters out any markdown file that is empty
+      if (file.stat.size === 0) return true;
+
+      return false;
+    })
     .filter(
       (file) =>
         // Filters any attachment that is not in use

--- a/src/util.ts
+++ b/src/util.ts
@@ -113,7 +113,19 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
       if (file.extension !== "md") return true;
 
       // Filter out any markdown files that are empty including only whitespace
-      if (!app.metadataCache.getFileCache(file).sections) return true;
+      const fileCache = app.metadataCache.getFileCache(file);
+      const sections = fileCache.sections;
+      if (sections === undefined) return true;
+
+      // Filter out any files that are empty and only contains ignored frontmatter properties
+      const fileFrontmatter = Object.keys(fileCache.frontmatter || {}).sort();
+      const settingsFrontmatter = settings.ignoredFrontmatter.sort();
+      if (settings.ignoredFrontmatter.length === 0) return false;
+
+      if (sections.length === 1 && sections.at(0).type === "yaml") {
+        if (fileFrontmatter.toString() === settingsFrontmatter.toString())
+          return true;
+      }
 
       return false; // Ignore all other files
     })


### PR DESCRIPTION
This PR allows empty markdown files containing **only** specific frontmatter tags to be added to the list of files to be removed.

Fixed #16 
