### PR TITLE
Fix: Simplified file and folder lookup

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -87,16 +87,19 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
     [],
   );
 
+  const allFilesAndFolders = app.vault.getAllLoadedFiles();
+  const allFolders = allFilesAndFolders.filter((node) =>
+    node.hasOwnProperty("children"),
+  );
   const emptyFolders = settings.removeFolders
-    ? app.vault
-        .getAllLoadedFiles()
-        .filter((node) => node.hasOwnProperty("children"))
-        .filter((folder: TFolder) => folder.children.length === 0)
+    ? allFolders.filter((folder: TFolder) => folder.children.length === 0)
     : [];
 
   // Get list of all files
-  const files: TFile[] = app.vault
-    .getFiles()
+  const allFiles = allFilesAndFolders.filter(
+    (node) => !node.hasOwnProperty("children"),
+  ) as TFile[];
+  const files: TFile[] = allFiles
     .filter((file) =>
       // Filters out only allowed extensions (including markdowns)
       file.extension.match(allowedExtensions),

--- a/src/util.ts
+++ b/src/util.ts
@@ -91,7 +91,7 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
     ? app.vault
         .getAllLoadedFiles()
         .filter((node) => node.hasOwnProperty("children"))
-        .filter((folder: TFolder) => folder["children"].length === 0)
+        .filter((folder: TFolder) => folder.children.length === 0)
     : [];
 
   // Get list of all files

--- a/src/util.ts
+++ b/src/util.ts
@@ -90,8 +90,8 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
   const emptyFolders = settings.removeFolders
     ? app.vault
         .getAllLoadedFiles()
-        .filter((child) => child.hasOwnProperty("children"))
-        .filter((child: TFolder) => child["children"].length === 0)
+        .filter((node) => node.hasOwnProperty("children"))
+        .filter((folder: TFolder) => folder["children"].length === 0)
     : [];
 
   // Get list of all files


### PR DESCRIPTION
Replaced usage of `getFiles` in addition to `getAllLoadedFiles` with only `getAllLoadedFiles`.
`getAllLoadedFiles` already gets everything.