### PR TITLE
Add: Exclude / Include folders toggle

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -15,13 +15,25 @@ const enUS: Locale = {
         },
       },
 
-      ExcludedFolders: {
-        Label: "Excluded folders",
-        Description: `
+      FolderFiltering: {
+        Excluded: {
+          Label: "Excluded folders",
+          Description: `
           Folders that should be excluded during cleanup.
           Paths are case-sensitive.
           One folder per line.`,
+        },
+        Included: {
+          Label: "Included folders",
+          Description: `
+          Folders that should be included during cleanup, only these folders will be scanned.
+          Paths are case-sensitive.
+          One folder per line.`,
+        },
+        Label: "Excluded / Included Folders",
         Placeholder: "Example:\nfolder/subfolder\nfolder2/subfolder2",
+        Description:
+          "The folders below should be excluded from or included in the cleanup process.",
       },
 
       Attachments: {

--- a/src/locales/locale.d.ts
+++ b/src/locales/locale.d.ts
@@ -12,10 +12,20 @@ export interface Locale {
         };
       };
 
-      ExcludedFolders: {
+      FolderFiltering: {
+        Excluded: {
+          Label: string;
+          Description: string;
+        };
+
+        Included: {
+          Label: string;
+          Description: string;
+        };
+
         Label: string;
-        Description: string;
         Placeholder: string;
+        Description: string;
       };
 
       Attachments: {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ import { ResetSettingsModal } from "./helpers";
 
 export interface FileCleanerSettings {
   deletionDestination: Deletion;
+  excludeInclude: boolean;
   excludedFolders: string[];
   attachmentExtensions: string[];
   deletionConfirmation: boolean;
@@ -16,6 +17,7 @@ export interface FileCleanerSettings {
 
 export const DEFAULT_SETTINGS: FileCleanerSettings = {
   deletionDestination: Deletion.SystemTrash,
+  excludeInclude: false,
   excludedFolders: [],
   attachmentExtensions: [],
   deletionConfirmation: true,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -93,8 +93,18 @@ export class FileCleanerSettingTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
-      .setName(translate().Settings.RegularOptions.ExcludedFolders.Label)
-      .setDesc(translate().Settings.RegularOptions.ExcludedFolders.Description)
+      .setName(
+        this.plugin.settings.excludeInclude
+          ? translate().Settings.RegularOptions.FolderFiltering.Included.Label
+          : translate().Settings.RegularOptions.FolderFiltering.Excluded.Label,
+      )
+      .setDesc(
+        this.plugin.settings.excludeInclude
+          ? translate().Settings.RegularOptions.FolderFiltering.Included
+              .Description
+          : translate().Settings.RegularOptions.FolderFiltering.Excluded
+              .Description,
+      )
       .addTextArea((text) => {
         text
           .setValue(this.plugin.settings.excludedFolders.join("\n"))
@@ -107,7 +117,7 @@ export class FileCleanerSettingTab extends PluginSettingTab {
             this.plugin.saveSettings();
           });
         text.setPlaceholder(
-          translate().Settings.RegularOptions.ExcludedFolders.Placeholder,
+          translate().Settings.RegularOptions.FolderFiltering.Placeholder,
         );
         text.inputEl.rows = 8;
         text.inputEl.cols = 30;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -79,6 +79,18 @@ export class FileCleanerSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName(translate().Settings.RegularOptions.FolderFiltering.Label)
+      .setDesc(translate().Settings.RegularOptions.FolderFiltering.Description)
+      .addToggle((toggle) => {
+        toggle.setValue(this.plugin.settings.excludeInclude);
+
+        toggle.onChange((value) => {
+          this.plugin.settings.excludeInclude = value;
+          this.display();
+        });
+      });
+
+    new Setting(containerEl)
       .setName(translate().Settings.RegularOptions.ExcludedFolders.Label)
       .setDesc(translate().Settings.RegularOptions.ExcludedFolders.Description)
       .addTextArea((text) => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,7 +6,7 @@ import { ResetSettingsModal } from "./helpers";
 
 export interface FileCleanerSettings {
   deletionDestination: Deletion;
-  excludeInclude: boolean;
+  excludeInclude: ExcludeInclude;
   excludedFolders: string[];
   attachmentExtensions: string[];
   deletionConfirmation: boolean;
@@ -14,10 +14,14 @@ export interface FileCleanerSettings {
   removeFolders: boolean;
   ignoredFrontmatter: string[];
 }
+export enum ExcludeInclude {
+  Exclude = Number(false),
+  Include = Number(true),
+}
 
 export const DEFAULT_SETTINGS: FileCleanerSettings = {
   deletionDestination: Deletion.SystemTrash,
-  excludeInclude: false,
+  excludeInclude: ExcludeInclude.Exclude,
   excludedFolders: [],
   attachmentExtensions: [],
   deletionConfirmation: true,
@@ -84,10 +88,10 @@ export class FileCleanerSettingTab extends PluginSettingTab {
       .setName(translate().Settings.RegularOptions.FolderFiltering.Label)
       .setDesc(translate().Settings.RegularOptions.FolderFiltering.Description)
       .addToggle((toggle) => {
-        toggle.setValue(this.plugin.settings.excludeInclude);
+        toggle.setValue(Boolean(this.plugin.settings.excludeInclude));
 
         toggle.onChange((value) => {
-          this.plugin.settings.excludeInclude = value;
+          this.plugin.settings.excludeInclude = Number(value);
           this.display();
         });
       });

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import { App, Notice, TAbstractFile, TFile, TFolder } from "obsidian";
-import { FileCleanerSettings } from "./settings";
+import { ExcludeInclude, FileCleanerSettings } from "./settings";
 import translate from "./i18n";
 import { Deletion } from "./enums";
 import { DeletionConfirmationModal } from "./helpers";
@@ -149,12 +149,15 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
         file,
     );
 
-  const filesAndFolders = [...files, ...emptyFolders].filter((file) =>
-    // Filter out files from excluded folders
-    settings.excludedFolders.length > 0
-      ? !file.path.match(excludedFoldersRegex)
-      : file,
-  );
+  const filesAndFolders = [...files, ...emptyFolders].filter((file) => {
+    // Filter out files from excluded / included folders
+    if (settings.excludedFolders.length === 0) return file;
+    else {
+      return settings.excludeInclude === ExcludeInclude.Exclude
+        ? !file.path.match(excludedFoldersRegex)
+        : file.path.match(excludedFoldersRegex);
+    }
+  });
 
   const indexingDuration = Date.now() - indexingStart;
   console.log(


### PR DESCRIPTION
- updated settings strings
- added toggle for using exclusion or inclusion of folders
- updated settings interface to allow for includeFolders
- updated setting for excluded folders with new labels and descriptions
- made excludeInclude an enum to make it easier to read
- updated final filter to use excluded/included folders

Fixes #25 
