### PR TITLE
Add support for Excalidraw

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Based on https://github.com/Johnson0907/obsidian-file-cleaner
 - Run on Startup (Optional)
 - Supports the following external plugins:
   - Admonition (as of v1.0.0 - [#57](https://github.com/husjon/obsidian-file-cleaner-redux/pull/57))
+  - Excalidraw (as of v1.1.0)
 
 ### How to use the plugin
 

--- a/src/helpers/extras/excalidraw.ts
+++ b/src/helpers/extras/excalidraw.ts
@@ -1,0 +1,5 @@
+import { App, TFile } from "obsidian";
+
+export function checkExcalidraw(file: TFile, app: App) {
+  console.log("excalidraw found");
+}

--- a/src/helpers/extras/excalidraw.ts
+++ b/src/helpers/extras/excalidraw.ts
@@ -1,5 +1,38 @@
 import { App, TFile } from "obsidian";
 
-export function checkExcalidraw(file: TFile, app: App) {
-  console.log("excalidraw found");
+interface ExcalidrawElement {
+  id: string;
+  isDeleted: boolean;
+}
+
+export async function checkExcalidraw(file: TFile, app: App) {
+  const content = await app.vault.cachedRead(file);
+
+  const blockStart = content.search(/{[ \t\n]*"type":[ ]*"excalidraw"/);
+  const blockEnd = content.search(/```\n?%%/);
+
+  if (blockStart < 0) return false;
+  if (blockEnd < 0) {
+    console.warn(
+      `Could not determine codeblock boundary for the following Excalidraw file: ${file.path}`,
+    );
+    return false;
+  }
+
+  const codeBlockRaw = content.slice(blockStart, blockEnd);
+
+  // Abort if the file could not be identified
+  if (codeBlockRaw.length === 0) return false;
+
+  const data = JSON.parse(codeBlockRaw);
+
+  const elements: ExcalidrawElement[] = data.elements;
+  if (elements.length === 0) return true;
+
+  // In the case where the Excalidraw file has been saved just after deleing the last element,
+  //  the element is still part of the file but tagged with `isDeleted`, if there are no such element it can be deleted.
+  const activeElements = elements.filter((el) => !el.isDeleted);
+  if (activeElements.length === 0) return true;
+
+  return false;
 }

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -76,3 +76,8 @@ export function getExtensions(settings: FileCleanerSettings) {
 export interface AppWithPlugins extends App {
   plugins: { plugins: Record<string, any> };
 }
+
+export function userHasPlugin(id: string, app: App) {
+  const plugins = (app as AppWithPlugins).plugins.plugins;
+  return plugins.hasOwnProperty(id);
+}

--- a/src/helpers/markdown.ts
+++ b/src/helpers/markdown.ts
@@ -33,3 +33,14 @@ export async function checkMarkdown(
 
   return false;
 }
+
+export async function getMarkdownSections(file: TFile, app: App, type = "") {
+  const cache = app.metadataCache.getFileCache(file);
+
+  if (!cache.sections) return [];
+
+  if (type !== "")
+    return cache.sections.filter((section) => section.type === type);
+
+  return cache.sections;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,7 +23,11 @@ async function checkFile(
   extensions: RegExp,
 ) {
   if (file.extension === "md") {
-    if (await checkExcalidraw(file, app)) return true
+    if (
+      userHasPlugin("obsidian-excalidraw-plugin", app) &&
+      (await checkExcalidraw(file, app))
+    )
+      return true;
 
     return await checkMarkdown(file, app, settings);
   } else if (file.extension === "canvas") {

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,8 +23,7 @@ async function checkFile(
   extensions: RegExp,
 ) {
   if (file.extension === "md") {
-    if (file.basename.endsWith(".excalidraw"))
-      return checkExcalidraw(file, app);
+    if (await checkExcalidraw(file, app)) return true
 
     return await checkMarkdown(file, app, settings);
   } else if (file.extension === "canvas") {

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,7 @@ import {
   getInUseAttachments,
   getSubFoldersInFolder,
   removeFiles,
-  AppWithPlugins,
+  userHasPlugin,
 } from "./helpers/helpers";
 import { getFolders } from "./helpers/helpers";
 import { checkMarkdown } from "./helpers/markdown";
@@ -61,8 +61,7 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
   const inUseAttachmentsInitial = getInUseAttachments(app);
   inUseAttachmentsInitial.push(...(await getCanvasAttachments(app)));
 
-  const plugins = (app as AppWithPlugins).plugins.plugins;
-  if (plugins.hasOwnProperty("obsidian-admonition"))
+  if (userHasPlugin("obsidian-admonition", app))
     inUseAttachmentsInitial.push(...(await getAdmonitionAttachments(app)));
 
   // Deduplicated array of attachments

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,6 +14,7 @@ import { checkCanvas, getCanvasAttachments } from "./helpers/canvas";
 import { DeletionConfirmationModal } from "./modals";
 import translate from "./i18n";
 import { getAdmonitionAttachments } from "./helpers/extras/admonition";
+import { checkExcalidraw } from "./helpers/extras/excalidraw";
 
 async function checkFile(
   app: App,
@@ -22,6 +23,9 @@ async function checkFile(
   extensions: RegExp,
 ) {
   if (file.extension === "md") {
+    if (file.basename.endsWith(".excalidraw"))
+      return checkExcalidraw(file, app);
+
     return await checkMarkdown(file, app, settings);
   } else if (file.extension === "canvas") {
     return await checkCanvas(file, app);


### PR DESCRIPTION
Adds support for Excalidraw files

Current implementation requires that the compression is disabled in teh Excalidraw Settings.  
`Obsidian Settings > Community plugins > Excalidraw > Saving > Compress Excalidraw JSON in Markdown`

![image](https://github.com/user-attachments/assets/4f8f582e-18d0-490b-b389-8eb1b20e9b9e)


- **added initial checkExcalidraw helper function**
- **added helper function to get the sections from a markdown file**
- **extended checkExcalidraw to parse the json object and delete the file if it has no elements**
- **extracted plugin check to helpers**
- **check if user has excalidraw installed before checking files**
