### PR TITLE
Automatically delete trash files older than X days

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -17,7 +17,7 @@ const enUS: Locale = {
       ObsidianTrashCleanupAge: {
         Label: "Trash directory age threshold",
         Description:
-          "Amount of days files can be in the `.trash` folder before they are permanently removed.",
+          "Amount of days files can be in the `.trash` folder before they are permanently removed (minimum 1 day).",
       },
 
       FolderFiltering: {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -14,6 +14,11 @@ const enUS: Locale = {
           PermanentDelete: "Permanently delete",
         },
       },
+      ObsidianTrashCleanupAge: {
+        Label: "Trash directory age threshold",
+        Description:
+          "Amount of days files can be in the `.trash` folder before they are permanently removed.",
+      },
 
       FolderFiltering: {
         Excluded: {

--- a/src/locales/locale.d.ts
+++ b/src/locales/locale.d.ts
@@ -11,6 +11,10 @@ export interface Locale {
           PermanentDelete: string;
         };
       };
+      ObsidianTrashCleanupAge: {
+        Label: string;
+        Description: string;
+      };
 
       FolderFiltering: {
         Excluded: {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -89,6 +89,29 @@ export class FileCleanerSettingTab extends PluginSettingTab {
             this.display();
           }),
       );
+    this.plugin.settings.deletionDestination === Deletion.ObsidianTrash &&
+      new Setting(containerEl)
+        .setName(
+          translate().Settings.RegularOptions.ObsidianTrashCleanupAge.Label,
+        )
+        .setDesc(
+          translate().Settings.RegularOptions.ObsidianTrashCleanupAge
+            .Description,
+        )
+        .addText((text) => {
+          const days = this.plugin.settings.obsidianTrashCleanupAge;
+
+          text.setPlaceholder("7");
+          text.setValue(days >= 0 ? String(days) : "");
+          text.inputEl.style.minWidth = "18rem";
+
+          text.onChange((value) => {
+            const days = Number(value.match(/^\d+/)) || -1;
+
+            this.plugin.settings.obsidianTrashCleanupAge = days;
+            this.plugin.saveSettings();
+          });
+        });
     // #endregion
 
     // #region Folder inclusion / exclusion

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ import { ResetSettingsModal } from "./modals";
 
 export interface FileCleanerSettings {
   deletionDestination: Deletion;
+  obsidianTrashCleanupAge: number;
   excludeInclude: ExcludeInclude;
   excludedFolders: string[];
   attachmentsExcludeInclude: ExcludeInclude;
@@ -22,6 +23,7 @@ export enum ExcludeInclude {
 
 export const DEFAULT_SETTINGS: FileCleanerSettings = {
   deletionDestination: Deletion.SystemTrash,
+  obsidianTrashCleanupAge: -1,
   excludeInclude: ExcludeInclude.Exclude,
   excludedFolders: [],
   attachmentsExcludeInclude: ExcludeInclude.Include,

--- a/src/util.ts
+++ b/src/util.ts
@@ -49,6 +49,28 @@ function isFolderIncluded(folder: TFolder, settings: FileCleanerSettings) {
   );
 }
 
+async function cleanTrashFolder(app: App, settings: FileCleanerSettings) {
+  if (settings.obsidianTrashCleanupAge < 0) return;
+  if (!app.vault.adapter.exists(".trash")) return;
+
+  const date = new Date();
+  const ageThreshold = date.setDate(
+    date.getDate() - settings.obsidianTrashCleanupAge,
+  );
+
+  const trashDirectory = await app.vault.adapter.list(".trash");
+  for (const file of trashDirectory.files) {
+    const f = await app.vault.adapter.stat(file);
+
+    if (f.ctime < ageThreshold) app.vault.adapter.remove(file);
+  }
+  for (const folder of trashDirectory.folders) {
+    const f = await app.vault.adapter.stat(folder);
+
+    if (f.ctime < ageThreshold) app.vault.adapter.rmdir(folder, true);
+  }
+}
+
 export async function runCleanup(app: App, settings: FileCleanerSettings) {
   const indexingStart = Date.now();
   console.group("File Cleaner Redux");
@@ -150,6 +172,8 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
     foldersToRemove.forEach((item) => console.debug(item.path));
     console.groupEnd();
   }
+
+  cleanTrashFolder(app, settings);
 
   console.groupEnd();
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -182,7 +182,8 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
     console.groupEnd();
   }
 
-  cleanTrashFolder(app, settings);
+  if (settings.deletionDestination === Deletion.ObsidianTrash)
+    cleanTrashFolder(app, settings);
 
   console.groupEnd();
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,6 +14,7 @@ import { checkCanvas, getCanvasAttachments } from "./helpers/canvas";
 import { DeletionConfirmationModal } from "./modals";
 import translate from "./i18n";
 import { getAdmonitionAttachments } from "./helpers/extras/admonition";
+import { Deletion } from "./enums";
 
 async function checkFile(
   app: App,
@@ -58,17 +59,25 @@ async function cleanTrashFolder(app: App, settings: FileCleanerSettings) {
     date.getDate() - settings.obsidianTrashCleanupAge,
   );
 
+  console.group("Checking '.trash' folder");
   const trashDirectory = await app.vault.adapter.list(".trash");
   for (const file of trashDirectory.files) {
     const f = await app.vault.adapter.stat(file);
 
-    if (f.ctime < ageThreshold) app.vault.adapter.remove(file);
+    if (f.ctime < ageThreshold) {
+      app.vault.adapter.remove(file);
+      console.debug("Removed file:", file);
+    }
   }
   for (const folder of trashDirectory.folders) {
     const f = await app.vault.adapter.stat(folder);
 
-    if (f.ctime < ageThreshold) app.vault.adapter.rmdir(folder, true);
+    if (f.ctime < ageThreshold) {
+      app.vault.adapter.rmdir(folder, true);
+      console.debug("Removed folder:", folder);
+    }
   }
+  console.groupEnd();
 }
 
 export async function runCleanup(app: App, settings: FileCleanerSettings) {


### PR DESCRIPTION
Adds support for cleaning up the Obsidians `.trash` folder based on an age threshold.

Changes:
- **added property FileCleanerSettings.obsidianTrashCleanupAge**
- **added labels**
- **added setting for setting "Trash directory age treshold"**
- **added function to check the users `.trash` folder and clean up files above a certain age threshold**
- **added some log messages**
- **only run cleanTrashFolder when Obsidian Trash is used**
