### PR TITLE
Re-add Excalidraw support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Based on https://github.com/Johnson0907/obsidian-file-cleaner
 - Run on Startup (Optional)
 - Supports the following external plugins:
   - Admonition (as of v1.0.0 - [#57](https://github.com/husjon/obsidian-file-cleaner-redux/pull/57))
-  - Excalidraw (as of v1.1.0)
+  - Excalidraw (as of v1.3.0)
+    Note: This does require JSON compression in Excalidraw to be turned off.
+    This can be done in Excalidraw Setting > Saving > Compress Excalidraw JSON in Markdown
 
 ### How to use the plugin
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Based on https://github.com/Johnson0907/obsidian-file-cleaner
 - Run on Startup (Optional)
 - Supports the following external plugins:
   - Admonition (as of v1.0.0 - [#57](https://github.com/husjon/obsidian-file-cleaner-redux/pull/57))
+  - Excalidraw (as of v1.1.0)
 
 ### How to use the plugin
 

--- a/src/helpers/extras/excalidraw.ts
+++ b/src/helpers/extras/excalidraw.ts
@@ -8,7 +8,7 @@ interface ExcalidrawElement {
 export async function checkExcalidraw(file: TFile, app: App) {
   const metadata = app.metadataCache;
   // @ts-ignore (getBacklinksForFile is not part of the type definition)
-  const links = Object.keys(metadata.getBacklinksForFile(file).data);
+  const links = metadata.getBacklinksForFile(file).keys();
 
   if (links.length > 0) return false;
 

--- a/src/helpers/extras/excalidraw.ts
+++ b/src/helpers/extras/excalidraw.ts
@@ -11,7 +11,7 @@ export async function checkExcalidraw(file: TFile, app: App) {
   const frontmatter = metadata.getFileCache(file).frontmatter;
   if (!frontmatter) return false;
   if (
-    !Object.keys(frontmatter).contains("excalidraw") &&
+    !Object.keys(frontmatter).contains("excalidraw-plugin") &&
     frontmatter.excalidraw !== "parsed"
   )
     return false;

--- a/src/helpers/extras/excalidraw.ts
+++ b/src/helpers/extras/excalidraw.ts
@@ -1,0 +1,38 @@
+import { App, TFile } from "obsidian";
+
+interface ExcalidrawElement {
+  id: string;
+  isDeleted: boolean;
+}
+
+export async function checkExcalidraw(file: TFile, app: App) {
+  const content = await app.vault.cachedRead(file);
+
+  const blockStart = content.search(/{[ \t\n]*"type":[ ]*"excalidraw"/);
+  const blockEnd = content.search(/```\n?%%/);
+
+  if (blockStart < 0) return false;
+  if (blockEnd < 0) {
+    console.warn(
+      `Could not determine codeblock boundary for the following Excalidraw file: ${file.path}`,
+    );
+    return false;
+  }
+
+  const codeBlockRaw = content.slice(blockStart, blockEnd);
+
+  // Abort if the file could not be identified
+  if (codeBlockRaw.length === 0) return false;
+
+  const data = JSON.parse(codeBlockRaw);
+
+  const elements: ExcalidrawElement[] = data.elements;
+  if (elements.length === 0) return true;
+
+  // In the case where the Excalidraw file has been saved just after deleing the last element,
+  //  the element is still part of the file but tagged with `isDeleted`, if there are no such element it can be deleted.
+  const activeElements = elements.filter((el) => !el.isDeleted);
+  if (activeElements.length === 0) return true;
+
+  return false;
+}

--- a/src/helpers/extras/excalidraw.ts
+++ b/src/helpers/extras/excalidraw.ts
@@ -7,6 +7,15 @@ interface ExcalidrawElement {
 
 export async function checkExcalidraw(file: TFile, app: App) {
   const metadata = app.metadataCache;
+
+  const frontmatter = metadata.getFileCache(file).frontmatter;
+  if (!frontmatter) return false;
+  if (
+    !Object.keys(frontmatter).contains("excalidraw") &&
+    frontmatter.excalidraw !== "parsed"
+  )
+    return false;
+
   // @ts-ignore (getBacklinksForFile is not part of the type definition)
   const links = metadata.getBacklinksForFile(file).keys();
 

--- a/src/helpers/extras/excalidraw.ts
+++ b/src/helpers/extras/excalidraw.ts
@@ -6,6 +6,12 @@ interface ExcalidrawElement {
 }
 
 export async function checkExcalidraw(file: TFile, app: App) {
+  const metadata = app.metadataCache;
+  // @ts-ignore (getBacklinksForFile is not part of the type definition)
+  const links = Object.keys(metadata.getBacklinksForFile(file).data);
+
+  if (links.length > 0) return false
+
   const content = await app.vault.cachedRead(file);
 
   const blockStart = content.search(/{[ \t\n]*"type":[ ]*"excalidraw"/);

--- a/src/helpers/extras/excalidraw.ts
+++ b/src/helpers/extras/excalidraw.ts
@@ -10,7 +10,7 @@ export async function checkExcalidraw(file: TFile, app: App) {
   // @ts-ignore (getBacklinksForFile is not part of the type definition)
   const links = Object.keys(metadata.getBacklinksForFile(file).data);
 
-  if (links.length > 0) return false
+  if (links.length > 0) return false;
 
   const content = await app.vault.cachedRead(file);
 

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -76,3 +76,8 @@ export function getExtensions(settings: FileCleanerSettings) {
 export interface AppWithPlugins extends App {
   plugins: { plugins: Record<string, any> };
 }
+
+export function userHasPlugin(id: string, app: App) {
+  const plugins = (app as AppWithPlugins).plugins.plugins;
+  return plugins.hasOwnProperty(id);
+}

--- a/src/helpers/markdown.ts
+++ b/src/helpers/markdown.ts
@@ -36,3 +36,14 @@ export async function checkMarkdown(
 
   return false;
 }
+
+export async function getMarkdownSections(file: TFile, app: App, type = "") {
+  const cache = app.metadataCache.getFileCache(file);
+
+  if (!cache.sections) return [];
+
+  if (type !== "")
+    return cache.sections.filter((section) => section.type === type);
+
+  return cache.sections;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,7 @@ import {
   getInUseAttachments,
   getSubFoldersInFolder,
   removeFiles,
-  AppWithPlugins,
+  userHasPlugin,
 } from "./helpers/helpers";
 import { getFolders } from "./helpers/helpers";
 import { checkMarkdown } from "./helpers/markdown";
@@ -15,6 +15,7 @@ import { DeletionConfirmationModal } from "./modals";
 import translate from "./i18n";
 import { getAdmonitionAttachments } from "./helpers/extras/admonition";
 import { Deletion } from "./enums";
+import { checkExcalidraw } from "./helpers/extras/excalidraw";
 
 async function checkFile(
   app: App,
@@ -23,6 +24,12 @@ async function checkFile(
   extensions: RegExp,
 ) {
   if (file.extension === "md") {
+    if (
+      userHasPlugin("obsidian-excalidraw-plugin", app) &&
+      (await checkExcalidraw(file, app))
+    )
+      return true;
+
     return await checkMarkdown(file, app, settings);
   } else if (file.extension === "canvas") {
     return await checkCanvas(file, app);
@@ -89,8 +96,7 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
   const inUseAttachmentsInitial = getInUseAttachments(app);
   inUseAttachmentsInitial.push(...(await getCanvasAttachments(app)));
 
-  const plugins = (app as AppWithPlugins).plugins.plugins;
-  if (plugins.hasOwnProperty("obsidian-admonition"))
+  if (userHasPlugin("obsidian-admonition", app))
     inUseAttachmentsInitial.push(...(await getAdmonitionAttachments(app)));
 
   // Deduplicated array of attachments


### PR DESCRIPTION
Excalidraw support was originally added in #66 as part of version 1.1.0, it did however have issues and was disabled in version 1.1.1.

Current implementation requires that JSON compression is disabled in Excalidraw Settings.  
`Obsidian Settings > Community plugins > Excalidraw > Saving > Compress Excalidraw JSON in Markdown`

![image](https://github.com/user-attachments/assets/4f8f582e-18d0-490b-b389-8eb1b20e9b9e)

Changes:
* Add Excalidraw support again
  * added initial checkExcalidraw helper function
  * added helper function to get the sections from a markdown file
  * extended checkExcalidraw to parse the json object and delete the file if it has no elements
  * extracted plugin check to helpers
  * check if user has excalidraw installed before checking files


* added check for backlinks, skip the file if there are any


* formatting


* get the backlink keys directly, instead of casting it to an array


* pre-check for excalidraw frontmatter fixes double parse


* frontmatter key has changed to 'excalidraw-plugin'


* Updated readme with correct version for Excalidraw


Fixes #68