### PR TITLE
Add feature: Ignore all frontmatter

### DIFF
--- a/src/helpers/markdown.ts
+++ b/src/helpers/markdown.ts
@@ -27,6 +27,8 @@ export async function checkMarkdown(
   // Check for file which contains only frontmatter whihc contains only the properties defined in the settings
   const fileCache = app.metadataCache.getFileCache(file);
   if (fileCache.sections.length === 1 && fileCache.frontmatter) {
+    if (settings.ignoreAllFrontmatter) return true;
+
     const frontmatterKeys = Object.keys(fileCache.frontmatter);
 
     return frontmatterKeys.every((frontmatterKey) =>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -68,6 +68,11 @@ const enUS: Locale = {
         Placeholder: "Example:\ncreated, updated",
       },
 
+      IgnoreAllFrontmatter: {
+        Label: "Ignore all frontmatter",
+        Description: "Ignores all frontmatter, including the ones set above.",
+      },
+
       PreviewDeletedFiles: {
         Label: "Preview deleted files",
         Description: "Show a confirmation box with list of files to be removed",

--- a/src/locales/locale.d.ts
+++ b/src/locales/locale.d.ts
@@ -54,6 +54,11 @@ export interface Locale {
         Placeholder: string;
       };
 
+      IgnoreAllFrontmatter: {
+        Label: string;
+        Description: string;
+      };
+
       PreviewDeletedFiles: {
         Label: string;
         Description: string;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -247,7 +247,13 @@ export class FileCleanerSettingTab extends PluginSettingTab {
         text.inputEl.style.maxWidth = "18rem";
         text.inputEl.style.minHeight = "4rem";
         text.inputEl.style.maxHeight = "12rem";
-      });
+      })
+      .setDisabled(this.plugin.settings.ignoreAllFrontmatter)
+      .controlEl.setCssStyles(
+        this.plugin.settings.ignoreAllFrontmatter && {
+          color: "",
+        },
+      );
 
     new Setting(containerEl)
       .setName(translate().Settings.RegularOptions.IgnoreAllFrontmatter.Label)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -248,6 +248,21 @@ export class FileCleanerSettingTab extends PluginSettingTab {
         text.inputEl.style.minHeight = "4rem";
         text.inputEl.style.maxHeight = "12rem";
       });
+
+    new Setting(containerEl)
+      .setName(translate().Settings.RegularOptions.IgnoreAllFrontmatter.Label)
+      .setDesc(
+        translate().Settings.RegularOptions.IgnoreAllFrontmatter.Description,
+      )
+      .addToggle((toggle) => {
+        toggle.setValue(this.plugin.settings.ignoreAllFrontmatter);
+
+        toggle.onChange((value) => {
+          this.plugin.settings.ignoreAllFrontmatter = value;
+          this.plugin.saveSettings();
+          this.display();
+        });
+      });
     // #endregion
 
     // #region Preview deleted files

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,6 +15,7 @@ export interface FileCleanerSettings {
   runOnStartup: boolean;
   removeFolders: boolean;
   ignoredFrontmatter: string[];
+  ignoreAllFrontmatter: boolean;
 }
 export enum ExcludeInclude {
   Exclude = Number(false),
@@ -32,6 +33,7 @@ export const DEFAULT_SETTINGS: FileCleanerSettings = {
   runOnStartup: false,
   removeFolders: false,
   ignoredFrontmatter: [],
+  ignoreAllFrontmatter: false,
 };
 
 export class FileCleanerSettingTab extends PluginSettingTab {


### PR DESCRIPTION
- **chore(FileCleanerSettings): added boolean to ignore all frontmatter**
- **chore(i18n/en): added label and description**
- **chore(Settings): added entry for "Ignore all frontmatter"**
- **chore(Settings): disable the "Ignored frontmatter" input when all frontmatter is ignored**
- **chore(checkMarkdown): return true instantly when ignoreAllFrontmatter is enabled**

Settings
![image](https://github.com/user-attachments/assets/4bf655e9-4f2e-48b6-9658-ca5598b955d0)


While **Ignore all frontmatter** is enabled, all **empty** files are now tagged for cleanup.
![image](https://github.com/user-attachments/assets/87eb8002-22af-4a11-a7b2-45c06d259ee6)
