### PR TITLE
79 trying to use a wildcard in include exclude folder list doesnt work and produces an error 1

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -26,14 +26,16 @@ const enUS: Locale = {
           Description: `
           Folders that should be excluded during cleanup.
           Paths are case-sensitive.
-          One folder per line.`,
+          One folder per line.
+          Supports regular expressions (wildcard matching can be done using \`.*\`)`,
         },
         Included: {
           Label: "Included folders",
           Description: `
           Folders that should be included during cleanup, only these folders will be scanned.
           Paths are case-sensitive.
-          One folder per line.`,
+          One folder per line.
+          Supports regular expressions (wildcard matching can be done using \`.*\`)`,
         },
         Label: "Excluded / Included Folders",
         Placeholder: "Example:\nfolder/subfolder\nfolder2/subfolder2",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -24,7 +24,7 @@ const enUS: Locale = {
         Excluded: {
           Label: "Excluded folders",
           Description: `
-          Folders that should be excluded during cleanup.
+          Folders that should be excluded during cleanup, all other folders will be scanned.
           Paths are case-sensitive.
           One folder per line.
           Supports regular expressions (wildcard matching can be done using \`.*\`)`,


### PR DESCRIPTION
- **chore(locales/en): added description about regular expression support**
- **chore(locales/en): expanded description for excluded folder to make it a bit more clear**


![image](https://github.com/user-attachments/assets/998bca33-ce57-48e7-ab52-2e589e122f29)
