### PR TITLE
Fix Markdown-style attachment link parsing in canvas nodes.

### DIFF
--- a/src/helpers/canvas.ts
+++ b/src/helpers/canvas.ts
@@ -21,7 +21,10 @@ function getCanvasCardAttachments(
 
   // Match attachments using Markdown syntax `![imagelabel](path_to_file)`
   for (const match of canvasNode.text.matchAll(/[!]\[.*?\]\((.*?)\)/g)) {
-    matchedFiles.push(match[1]);
+    matchedFiles.push(
+      // markdown link uses URL encoding for links (%20 is a space)
+      match[1].replace(/%20/gi, " "),
+    );
   }
 
   const files = matchedFiles.map((filePath) => {

--- a/src/helpers/canvas.ts
+++ b/src/helpers/canvas.ts
@@ -20,7 +20,7 @@ function getCanvasCardAttachments(
   }
 
   // Match attachments using Markdown syntax `![imagelabel](path_to_file)`
-  for (const match of canvasNode.text.matchAll(/[!]\[.*?\]\((.*?)\)/g)) {
+  for (const match of canvasNode.text.matchAll(/[!]\[.*?\]\((.*)\)/g)) {
     matchedFiles.push(
       // markdown link uses URL encoding for links (%20 is a space)
       match[1].replace(/%20/gi, " "),

--- a/src/helpers/canvas.ts
+++ b/src/helpers/canvas.ts
@@ -14,12 +14,12 @@ function getCanvasCardAttachments(
 ) {
   const matchedFiles = [];
 
-  // Match attachments using the syntax `![[path_to_file|imagelabel]]`
+  // Match attachments using Wikilink syntax `![[path_to_file|imagelabel]]`
   for (const match of canvasNode.text.matchAll(/[!]?\[\[(.*?)\]\]/g)) {
     matchedFiles.push(match[1].split("|")[0]); // strip of the label
   }
 
-  // Match attachments using the syntax `![imagelabel](path_to_file)`
+  // Match attachments using Markdown syntax `![imagelabel](path_to_file)`
   for (const match of canvasNode.text.matchAll(/[!]\[.*?\]\((.*?)\)/g)) {
     matchedFiles.push(match[1]);
   }


### PR DESCRIPTION
Markdown-style attachment links uses url encoding meaning spaces are replaced with `%20`.
This caused the lookup to look for filenames with literally `%20` in the name if it used spaces.

This PR also makes it so that filenames can have parenthesis in the filename.