### PR TITLE
fix(getCanvasAttachments): filter out falsely matched attachments

### DIFF
--- a/src/helpers/canvas.ts
+++ b/src/helpers/canvas.ts
@@ -74,9 +74,15 @@ export async function getCanvasAttachments(app: App) {
       }),
   );
 
-  return canvasAttachmentsInitial
-    .filter((f) => f.length > 0)
-    .reduce((prev, cur) => [...prev, ...cur], []);
+  return (
+    canvasAttachmentsInitial
+      // filter out undefined (falsely reported files)
+      // this can happen for example if a canvas node uses template strings that is prefixed with attachment-style syntax.
+      // e.g. prefixed with Wikilink-style `[[` and `![[` or Markdown-style `![`
+      .filter((f) => f)
+      .filter((f) => f.length > 0)
+      .reduce((prev, cur) => [...prev, ...cur], [])
+  );
 }
 
 export async function checkCanvas(file: TFile, app: App) {


### PR DESCRIPTION
If using a templates which builds on the attachment syntax (prefixed with Wikilink-style `[[` and `![[` or Markdown-style `![`), this can make the regular expression match these blobs.
When the match is passed on to Obsidians getFirstLinkpathDest it returns undefined.

These undefined matches are now filtered out.