### PR TITLE
fix(getCanvasCardAttachments): return only if the FileLink exist

### DIFF
--- a/src/helpers/canvas.ts
+++ b/src/helpers/canvas.ts
@@ -28,7 +28,11 @@ function getCanvasCardAttachments(
   }
 
   const files = matchedFiles.map((filePath) => {
-    return app.metadataCache.getFirstLinkpathDest(filePath, canvas.path).path;
+    const fileLink = app.metadataCache.getFirstLinkpathDest(
+      filePath,
+      canvas.path,
+    );
+    if (fileLink) return fileLink.path;
   });
 
   return files;


### PR DESCRIPTION
Since `getFirstLinkpathDest` returns null for non-existing files, we need to check if we do have a TFile object prior to accessing `.path`


Fixes #93 (notification issue)