### PR TITLE
fix(parseCodeblock): only check for codeblock fence in the beginning of the codeblock

### DIFF
--- a/src/helpers/codeblock.ts
+++ b/src/helpers/codeblock.ts
@@ -109,13 +109,13 @@ function parseCodeblock(codeblock: string): CodeBlock | null {
    *   ```
    */
 
-  if (!codeblock.match(/^[`~]{3,}.*?[`~]{3,}$/g)) return null;
+  const fence = codeblock.match(/^[`~]{3,}/g);
 
-  const fenceType = codeblock[0];
+  if (!fence) return null;
 
   const content = codeblock
-    .replace(RegExp(`^${fenceType}+`), "") //  strip of the code block fence at the beginning
-    .replace(RegExp(`${fenceType}+$`), ""); // strip of the code block fence at the end
+    .replace(RegExp(`^${fence}+`), "") //  strip of the code block fence at the beginning
+    .replace(RegExp(`${fence}+$`), ""); // strip of the code block fence at the end
 
   const language = content.split(/[\r\n]+/)[0];
 


### PR DESCRIPTION
Codeblocks do not strictly need the ending fence to be valid.
If the ending fence is there, we strip it off.