### PR TITLE
Add support for Meld Encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Based on https://github.com/Johnson0907/obsidian-file-cleaner
   - Excalidraw (as of v1.3.0)
     Note: This does require JSON compression in Excalidraw to be turned off.
     This can be done in Excalidraw Setting > Saving > Compress Excalidraw JSON in Markdown
+  - Meld Encrypt (as of v1.9.0)
+    Note: File Cleaner Redux cannot parse these encrypted files or inline blobs and can therefore not find file links or references.
 
 ### How to use the plugin
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -43,6 +43,11 @@ async function checkFile(
     return await checkCanvas(file, app);
   }
 
+  // Explicit plugin support
+  if (userHasPlugin("meld-encrypt", app) && file.extension === "mdenc") {
+    return false;
+  }
+
   if (settings.attachmentsExcludeInclude === ExcludeInclude.Include) {
     return file.extension.match(extensions);
   } else if (settings.attachmentsExcludeInclude === ExcludeInclude.Exclude) {


### PR DESCRIPTION
This PR adds support for the Meld Encrypt Plugin

It makes it so that if the user has the plugin installed, any mdenc files will be omitted from the cleanup sequence.

- **feat(checkFile): added explicit support for Meld Encrypt**
- **chore(README): added entry about Meld Encrypt**
