### PR TITLE
Removed Meld Encrypt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Based on https://github.com/Johnson0907/obsidian-file-cleaner
   - Excalidraw (as of v1.3.0)
     Note: This does require JSON compression in Excalidraw to be turned off.
     This can be done in Excalidraw Setting > Saving > Compress Excalidraw JSON in Markdown
-  - Meld Encrypt (as of v1.9.0)
-    Note: File Cleaner Redux cannot parse these encrypted files or inline blobs and can therefore not find file links or references.
 
 ### How to use the plugin
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -43,11 +43,6 @@ async function checkFile(
     return await checkCanvas(file, app);
   }
 
-  // Explicit plugin support
-  if (userHasPlugin("meld-encrypt", app) && file.extension === "mdenc") {
-    return false;
-  }
-
   if (settings.attachmentsExcludeInclude === ExcludeInclude.Include) {
     return file.extension.match(extensions);
   } else if (settings.attachmentsExcludeInclude === ExcludeInclude.Exclude) {


### PR DESCRIPTION
After some more discussion in #102 the support isn't required, mainly because File Cleaner Redux cannot parse these files for attachments.
Also the extension exclusion can be set in the settings for the plugin.