### PR TITLE
Allow deletion of empty Markdown files with backlinks

### DIFF
--- a/src/helpers/markdown.ts
+++ b/src/helpers/markdown.ts
@@ -16,7 +16,11 @@ export async function checkMarkdown(
     String,
     Array<any>
   >;
-  if (links.size > 0) return false;
+  if (
+    links.size > 0 &&
+    settings.deleteEmptyMarkdownFilesWithBacklinks === false
+  )
+    return false;
 
   // Checks for filesize to be literally 0 bytes
   if (file.stat.size === 0) return true;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -106,6 +106,12 @@ const enUS: Locale = {
         Description: "Removes Markdown files if their size is 0",
       },
 
+      DeleteEmptyMarkdownFilesWithBacklinks: {
+        Label: "Delete empty Markdown files with backlinks",
+        Description:
+          "Removes empty Markdown files even if they are linked to by other files.",
+      },
+
       RemoveFolders: {
         Label: "Remove folders",
         Description: "Include folders in cleanup",

--- a/src/locales/locale.d.ts
+++ b/src/locales/locale.d.ts
@@ -85,6 +85,11 @@ export interface Locale {
         Description: string;
       };
 
+      DeleteEmptyMarkdownFilesWithBacklinks: {
+        Label: string;
+        Description: string;
+      };
+
       RemoveFolders: {
         Label: string;
         Description: string;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,6 +18,7 @@ export interface FileCleanerSettings {
   ignoreAllFrontmatter: boolean;
   codeblockTypes: string[];
   deleteEmptyMarkdownFiles: boolean;
+  deleteEmptyMarkdownFilesWithBacklinks: boolean;
   fileAgeThreshold: number;
   closeNewTabs: boolean;
 }
@@ -40,6 +41,7 @@ export const DEFAULT_SETTINGS: FileCleanerSettings = {
   ignoreAllFrontmatter: false,
   codeblockTypes: [],
   deleteEmptyMarkdownFiles: true,
+  deleteEmptyMarkdownFilesWithBacklinks: false,
   fileAgeThreshold: 0,
   closeNewTabs: false,
 };
@@ -249,6 +251,30 @@ export class FileCleanerSettingTab extends PluginSettingTab {
           this.display();
         });
       });
+    // #endregion
+
+    // #region Delete empty Markdown files
+    this.plugin.settings.deleteEmptyMarkdownFiles &&
+      new Setting(containerEl)
+        .setName(
+          translate().Settings.RegularOptions
+            .DeleteEmptyMarkdownFilesWithBacklinks.Label,
+        )
+        .setDesc(
+          translate().Settings.RegularOptions
+            .DeleteEmptyMarkdownFilesWithBacklinks.Description,
+        )
+        .addToggle((toggle) => {
+          toggle.setValue(
+            this.plugin.settings.deleteEmptyMarkdownFilesWithBacklinks,
+          );
+
+          toggle.onChange((value) => {
+            this.plugin.settings.deleteEmptyMarkdownFilesWithBacklinks = value;
+            this.plugin.saveSettings();
+            this.display();
+          });
+        });
     // #endregion
 
     // #region Ignored frontmatter


### PR DESCRIPTION
This PR adds a setting to allow for deleting empty Markdown files even if they are linked to by other files (defaulted to false).

<img width="767" height="121" alt="image" src="https://github.com/user-attachments/assets/a0ecb027-9af0-485d-9d0b-587ceb293837" />

- **feat(locale): added entries for DeleteEmptyMarkdownFilesWithBacklinks**
- **feat(settings): added entry for DeleteEmptyMarkdownFilesWithBacklinks defaulted to false**
- **feat(markdown): now also checks if linked markdown files should be deleted**
