### PR TITLE
Fix: "Select all" and "Unselect all" now uses icons on mobile

### DIFF
--- a/src/modals/DeletionConfirmationModalComponent.svelte
+++ b/src/modals/DeletionConfirmationModalComponent.svelte
@@ -1,6 +1,18 @@
 <script lang="ts">
-  import { ExternalLink, File, FolderOpen } from "lucide-svelte";
-  import { TFolder, type App, type TAbstractFile, type TFile } from "obsidian";
+  import {
+    ExternalLink,
+    File,
+    FolderOpen,
+    Square,
+    SquareCheckBig,
+  } from "lucide-svelte";
+  import {
+    Platform,
+    TFolder,
+    type App,
+    type TAbstractFile,
+    type TFile,
+  } from "obsidian";
   import { removeFiles } from "src/helpers/helpers";
   import translate from "src/i18n";
   import type { FileCleanerSettings } from "src/settings";
@@ -99,7 +111,11 @@
         filesAndFoldersSorted.map((f) => addEntry(f));
       }}
     >
-      {translate().Modals.ButtonSelectAll}
+      {#if Platform.isMobile}
+        <SquareCheckBig />
+      {:else}
+        {translate().Modals.ButtonSelectAll}
+      {/if}
     </button>
     <button
       disabled={!unselectAllAvailable}
@@ -107,7 +123,11 @@
         filesAndFoldersSorted.map((f) => removeEntry(f));
       }}
     >
-      {translate().Modals.ButtonUnselectAll}
+      {#if Platform.isMobile}
+        <Square />
+      {:else}
+        {translate().Modals.ButtonUnselectAll}
+      {/if}
     </button>
   </div>
 


### PR DESCRIPTION
This PR makes it so that "Select all" and "Unselect all" now uses icons on mobile devices.

| old | new |
|  -  |  -  |
| <img width="350" alt="Image" src="https://github.com/user-attachments/assets/1ac24089-1925-406b-ba4c-64c4ae2faf61" /> | <img width="350" alt="app___obsidian md_index html(iPhone SE)" src="https://github.com/user-attachments/assets/7689c44a-e7e1-4643-b7bc-984f2c5eac00" /> |