### PR TITLE
Add: cleanup of empty files when closed

### DIFF
--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -3,7 +3,7 @@ import { type FileCleanerSettings } from "../settings";
 import { Deletion } from "../enums";
 import translate from "../i18n";
 
-async function removeFile(
+export async function removeFile(
   file: TAbstractFile,
   app: App,
   settings: FileCleanerSettings,

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -8,6 +8,8 @@ export async function removeFile(
   app: App,
   settings: FileCleanerSettings,
 ) {
+  if (!(await app.vault.adapter.exists(file.path))) return;
+
   switch (settings.deletionDestination) {
     case Deletion.Permanent:
       await app.vault.delete(file, true);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
 import { runCleanup, scanVault } from "./util";
 import translate from "./i18n";
 import { checkMarkdown } from "./helpers/markdown";
+import { removeFile } from "./helpers/helpers";
 
 export default class FileCleanerPlugin extends Plugin {
   plugin: FileCleanerPlugin;
@@ -45,7 +46,7 @@ export default class FileCleanerPlugin extends Plugin {
           .filter((f) => !currentlyOpenedFiles.includes(f))
           .forEach(async (f) => {
             if (await checkMarkdown(f, this.app, this.settings))
-              runCleanup([f], [], this.app, {
+              removeFile(f, this.app, {
                 ...this.settings,
                 deletionConfirmation: false,
               });

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,23 +14,21 @@ export default class FileCleanerPlugin extends Plugin {
   async onload() {
     await this.loadSettings();
 
-    this.addRibbonIcon("trash", translate().Buttons.CleanFiles, () => {
-      runCleanup(this.app, this.settings);
-    });
+    this.addRibbonIcon(
+      "trash",
+      translate().Buttons.CleanFiles,
+      this.runVaultCleanup,
+    );
 
     this.addCommand({
       id: "clean-files",
       name: translate().Buttons.CleanFiles,
-      callback: () => {
-        runCleanup(this.app, this.settings);
-      },
+      callback: this.runVaultCleanup,
     });
 
     this.addSettingTab(new FileCleanerSettingTab(this.app, this));
 
-    setTimeout(() => {
-      if (this.settings.runOnStartup) runCleanup(this.app, this.settings);
-    }, 1000);
+    if (this.settings.runOnStartup) setTimeout(this.runVaultCleanup, 1000);
   }
 
   onunload() {}
@@ -42,4 +40,8 @@ export default class FileCleanerPlugin extends Plugin {
   async saveSettings() {
     await this.saveData(this.settings);
   }
+
+  private runVaultCleanup = async () => {
+    runCleanup(this.app, this.settings);
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,10 +46,7 @@ export default class FileCleanerPlugin extends Plugin {
           .filter((f) => !currentlyOpenedFiles.includes(f))
           .forEach(async (f) => {
             if (await checkMarkdown(f, this.app, this.settings))
-              removeFile(f, this.app, {
-                ...this.settings,
-                deletionConfirmation: false,
-              });
+              removeFile(f, this.app, this.settings);
           });
 
         this.lastOpenedFiles = currentlyOpenedFiles;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_SETTINGS,
   FileCleanerSettingTab,
 } from "./settings";
-import { runCleanup } from "./util";
+import { runCleanup, scanVault } from "./util";
 import translate from "./i18n";
 
 export default class FileCleanerPlugin extends Plugin {
@@ -42,6 +42,10 @@ export default class FileCleanerPlugin extends Plugin {
   }
 
   private runVaultCleanup = async () => {
-    runCleanup(this.app, this.settings);
+    const { filesToRemove, foldersToRemove } = await scanVault(
+      this.app,
+      this.settings,
+    );
+    runCleanup(filesToRemove, foldersToRemove, this.app, this.settings);
   };
 }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -131,7 +131,7 @@ const enUS: Locale = {
       DeleteEmptyFileOnClose: {
         Label: "Delete empty file on close",
         Description:
-          "Whether to perform cleanup of the recently closed markdown files. Only cleans empty files",
+          "Whether to perform cleanup of the recently closed markdown files. Only cleans empty files matching the rules above",
       },
 
       PreviewDeletedFiles: {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -128,6 +128,12 @@ const enUS: Locale = {
         Description: "Close leftover New tabs",
       },
 
+      DeleteEmptyFileOnClose: {
+        Label: "Delete empty file on close",
+        Description:
+          "Whether to perform cleanup of the recently closed markdown files. Only cleans empty files",
+      },
+
       PreviewDeletedFiles: {
         Label: "Preview deleted files",
         Description: "Show a confirmation box with list of files to be removed",

--- a/src/locales/locale.d.ts
+++ b/src/locales/locale.d.ts
@@ -105,6 +105,10 @@ export interface Locale {
         Label: string;
         Description: string;
       };
+      DeleteEmptyFileOnClose: {
+        Label: string;
+        Description: string;
+      };
 
       PreviewDeletedFiles: {
         Label: string;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -21,6 +21,7 @@ export interface FileCleanerSettings {
   deleteEmptyMarkdownFilesWithBacklinks: boolean;
   fileAgeThreshold: number;
   closeNewTabs: boolean;
+  deleteEmptyFileOnClose: boolean;
 }
 export enum ExcludeInclude {
   Exclude = Number(false),
@@ -44,6 +45,7 @@ export const DEFAULT_SETTINGS: FileCleanerSettings = {
   deleteEmptyMarkdownFilesWithBacklinks: false,
   fileAgeThreshold: 0,
   closeNewTabs: false,
+  deleteEmptyFileOnClose: false,
 };
 
 export class FileCleanerSettingTab extends PluginSettingTab {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -419,6 +419,20 @@ export class FileCleanerSettingTab extends PluginSettingTab {
       });
     // #endregion
 
+    // #region Delete empty file on close
+    new Setting(containerEl)
+      .setName(translate().Settings.Other.DeleteEmptyFileOnClose.Label)
+      .setDesc(translate().Settings.Other.DeleteEmptyFileOnClose.Description)
+      .addToggle((toggle) => {
+        toggle.setValue(this.plugin.settings.closeNewTabs);
+
+        toggle.onChange((value) => {
+          this.plugin.settings.deleteEmptyFileOnClose = value;
+          this.plugin.saveSettings();
+        });
+      });
+    // #endregion
+
     // #region Preview deleted files
     new Setting(containerEl)
       .setName(translate().Settings.Other.PreviewDeletedFiles.Label)

--- a/src/util.ts
+++ b/src/util.ts
@@ -95,7 +95,7 @@ async function cleanTrashFolder(app: App, settings: FileCleanerSettings) {
   console.groupEnd();
 }
 
-export async function runCleanup(app: App, settings: FileCleanerSettings) {
+export async function scanVault(app: App, settings: FileCleanerSettings) {
   const indexingStart = Date.now();
   console.group("File Cleaner Redux");
   console.log(`Starting cleanup`);
@@ -176,6 +176,18 @@ export async function runCleanup(app: App, settings: FileCleanerSettings) {
     `Found ${filesToRemove.length} files and ${foldersToRemove.length} folders to clean up.`,
   );
 
+  return {
+    filesToRemove,
+    foldersToRemove,
+  };
+}
+
+export async function runCleanup(
+  filesToRemove: TFile[],
+  foldersToRemove: TFolder[],
+  app: App,
+  settings: FileCleanerSettings,
+) {
   const filesAndFolders: TAbstractFile[] = [...filesToRemove];
   filesAndFolders.push(...foldersToRemove.reverse());
 


### PR DESCRIPTION
This PR adds an option to clean up empty markdown files when its respective tab is closed (default to **off**).