### PR TITLE
Fix: Added missing check for folder inclusion/exclusion for file-close cleanup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,15 @@ import { FileView, Plugin, TFile } from "obsidian";
 import {
   type FileCleanerSettings,
   DEFAULT_SETTINGS,
+  ExcludeInclude,
   FileCleanerSettingTab,
 } from "./settings";
-import { runCleanup, scanVault } from "./util";
+import {
+  isFolderExcluded,
+  isFolderIncluded,
+  runCleanup,
+  scanVault,
+} from "./util";
 import translate from "./i18n";
 import { checkMarkdown } from "./helpers/markdown";
 import { removeFile } from "./helpers/helpers";
@@ -45,6 +51,14 @@ export default class FileCleanerPlugin extends Plugin {
         this.lastOpenedFiles
           .filter((f) => !currentlyOpenedFiles.includes(f))
           .forEach(async (f) => {
+            if (
+              (this.settings.excludeInclude === ExcludeInclude.Exclude &&
+                isFolderExcluded(f.parent, this.settings)) ||
+              (this.settings.excludeInclude === ExcludeInclude.Include &&
+                isFolderIncluded(f.parent, this.settings))
+            )
+              return;
+
             if (await checkMarkdown(f, this.app, this.settings))
               removeFile(f, this.app, this.settings);
           });

--- a/src/util.ts
+++ b/src/util.ts
@@ -50,14 +50,20 @@ async function checkFile(
   }
 }
 
-function isFolderExcluded(folder: TFolder, settings: FileCleanerSettings) {
+export function isFolderExcluded(
+  folder: TFolder,
+  settings: FileCleanerSettings,
+) {
   return (
     settings.excludedFolders
       .map((excludedFolder) => folder.path.match(RegExp(`^${excludedFolder}`)))
       .filter((x) => x).length > 0
   );
 }
-function isFolderIncluded(folder: TFolder, settings: FileCleanerSettings) {
+export function isFolderIncluded(
+  folder: TFolder,
+  settings: FileCleanerSettings,
+) {
   return (
     settings.excludedFolders
       .map((excludedFolder) => folder.path.match(RegExp(`^${excludedFolder}`)))


### PR DESCRIPTION
Since the file-close cleanup runs without all the extra vault scanning, the folder inclusion/exclusion check was not run.
This is now added as part of this procedure.