### PR TITLE
fix(scanVault): ignore Obsidian base files

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -157,6 +157,7 @@ export async function scanVault(app: App, settings: FileCleanerSettings) {
     let childrenCount = files.length;
     for (const file of files) {
       if (inUseAttachments.includes(file.path)) continue;
+      if (file.extension === "base") continue;
 
       if (await checkFile(app, settings, file, extensions)) {
         filesToRemove.push(file);


### PR DESCRIPTION
Even in their default state, base files can be useful for someone,
due to this there is no way of really knowing when these are empty.
For now we completely ignore cleaning up these files unless there is a
need for it in the future.

Closes: https://github.com/husjon/obsidian-file-cleaner-redux/issues/138