### PR TITLE
Add config option to tune status messages

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -9,3 +9,8 @@ export enum Notification {
   ShowOnlyErrors = "showOnlyErrors",
   HideAll = "hideAll",
 }
+
+export enum NotificationType {
+  Info,
+  Error,
+}

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -3,3 +3,9 @@ export enum Deletion {
   ObsidianTrash = "obsidian",
   Permanent = "permanent",
 }
+
+export enum Notification {
+  ShowAll = "showAll",
+  ShowOnlyErrors = "showOnlyErrors",
+  HideAll = "hideAll",
+}

--- a/src/helpers/canvas.ts
+++ b/src/helpers/canvas.ts
@@ -1,4 +1,5 @@
-import { App, Notice, TFile } from "obsidian";
+import { App, TFile } from "obsidian";
+import { notify } from "./helpers";
 
 interface CanvasNode {
   id: string;
@@ -71,7 +72,7 @@ export async function getCanvasAttachments(app: App) {
 
               return [...fileNodes, ...cardNodes];
             } catch (error) {
-              new Notice(`Failed to parse canvas file: ${file.path}`);
+              notify(`Failed to parse canvas file: ${file.path}`);
             }
           },
         );

--- a/src/helpers/canvas.ts
+++ b/src/helpers/canvas.ts
@@ -1,6 +1,7 @@
 import { App, TFile } from "obsidian";
 import { notify } from "./helpers";
 import { NotificationType } from "src/enums";
+import translate from "src/i18n";
 
 interface CanvasNode {
   id: string;
@@ -74,7 +75,7 @@ export async function getCanvasAttachments(app: App) {
               return [...fileNodes, ...cardNodes];
             } catch (error) {
               notify(
-                `Failed to parse canvas file: ${file.path}`,
+                `${translate().Notifications.FailedToParseCanvas}: ${file.path}`,
                 NotificationType.Error,
               );
             }

--- a/src/helpers/canvas.ts
+++ b/src/helpers/canvas.ts
@@ -1,5 +1,6 @@
 import { App, TFile } from "obsidian";
 import { notify } from "./helpers";
+import { NotificationType } from "src/enums";
 
 interface CanvasNode {
   id: string;
@@ -72,7 +73,10 @@ export async function getCanvasAttachments(app: App) {
 
               return [...fileNodes, ...cardNodes];
             } catch (error) {
-              notify(`Failed to parse canvas file: ${file.path}`);
+              notify(
+                `Failed to parse canvas file: ${file.path}`,
+                NotificationType.Error,
+              );
             }
           },
         );

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -84,6 +84,11 @@ export function userHasPlugin(id: string, app: App) {
   return plugins.hasOwnProperty(id);
 }
 
+export function getSettings() {
+  return this.app.plugins.plugins["file-cleaner-redux"]
+    .settings as FileCleanerSettings;
+}
+
 export function notify(message: string) {
   new Notice(message);
 }

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,6 +1,6 @@
 import { App, Notice, TAbstractFile, TFile, TFolder } from "obsidian";
 import { type FileCleanerSettings } from "../settings";
-import { Deletion } from "../enums";
+import { Deletion, Notification } from "../enums";
 import translate from "../i18n";
 
 export async function removeFile(
@@ -90,5 +90,9 @@ export function getSettings() {
 }
 
 export function notify(message: string) {
+  const settings = getSettings();
+
+  if (settings.notifications === Notification.HideAll) return;
+
   new Notice(message);
 }

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,6 +1,6 @@
 import { App, Notice, TAbstractFile, TFile, TFolder } from "obsidian";
 import { type FileCleanerSettings } from "../settings";
-import { Deletion, Notification } from "../enums";
+import { Deletion, Notification, NotificationType } from "../enums";
 import translate from "../i18n";
 
 export async function removeFile(
@@ -89,10 +89,18 @@ export function getSettings() {
     .settings as FileCleanerSettings;
 }
 
-export function notify(message: string) {
+export function notify(
+  message: string,
+  type: NotificationType = NotificationType.Info,
+) {
   const settings = getSettings();
 
   if (settings.notifications === Notification.HideAll) return;
+  if (
+    settings.notifications === Notification.ShowOnlyErrors &&
+    type !== NotificationType.Error
+  )
+    return;
 
   new Notice(message);
 }

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -32,9 +32,9 @@ export async function removeFiles(
     for (const file of files) {
       removeFile(file, app, settings);
     }
-    new Notice(translate().Notifications.CleanSuccessful);
+    notify(translate().Notifications.CleanSuccessful);
   } else {
-    new Notice(translate().Notifications.NoFileToClean);
+    notify(translate().Notifications.NoFileToClean);
   }
 }
 
@@ -82,4 +82,8 @@ export interface AppWithPlugins extends App {
 export function userHasPlugin(id: string, app: App) {
   const plugins = (app as AppWithPlugins).plugins.plugins;
   return plugins.hasOwnProperty(id);
+}
+
+export function notify(message: string) {
+  new Notice(message);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,8 @@ import {
 } from "./util";
 import translate from "./i18n";
 import { checkMarkdown } from "./helpers/markdown";
-import { removeFile } from "./helpers/helpers";
+import { notify, removeFile } from "./helpers/helpers";
+import { NotificationType } from "./enums";
 
 export default class FileCleanerPlugin extends Plugin {
   plugin: FileCleanerPlugin;
@@ -79,10 +80,19 @@ export default class FileCleanerPlugin extends Plugin {
   }
 
   private runVaultCleanup = async () => {
-    const { filesToRemove, foldersToRemove } = await scanVault(
-      this.app,
-      this.settings,
-    );
-    runCleanup(filesToRemove, foldersToRemove, this.app, this.settings);
+    try {
+      const { filesToRemove, foldersToRemove } = await scanVault(
+        this.app,
+        this.settings,
+      );
+
+      await runCleanup(filesToRemove, foldersToRemove, this.app, this.settings);
+    } catch (error) {
+      notify(
+        "An unexected error occurred, please check the console.",
+        NotificationType.Error,
+      );
+      throw error;
+    }
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ export default class FileCleanerPlugin extends Plugin {
       await runCleanup(filesToRemove, foldersToRemove, this.app, this.settings);
     } catch (error) {
       notify(
-        "An unexected error occurred, please check the console.",
+        translate().Notifications.UnexpectedErrorOccurred,
         NotificationType.Error,
       );
       throw error;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -19,6 +19,17 @@ const enUS: Locale = {
         Description:
           "Amount of days files can be in the `.trash` folder before they are permanently removed (minimum 1 day).",
       },
+
+      Notifications: {
+        Label: "Notifications",
+        Description: "How should notifications for this plugin be handled",
+
+        Options: {
+          ShowAllNotifications: "Show all",
+          ShowOnlyErrors: "Show only errors",
+          HideAll: "Hide all",
+        },
+      },
     },
 
     Folders: {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -208,6 +208,11 @@ const enUS: Locale = {
     CleanSuccessful: "Clean successful",
     NoFileToClean: "No file to clean",
     SettingsReset: "File Cleaner Redux: Setting reset",
+
+    FailedToParseCanvas: "Failed to parse canvas file",
+
+    UnexpectedErrorOccurred:
+      "An unexpected error occurred, please check the console",
   },
 };
 

--- a/src/locales/locale.d.ts
+++ b/src/locales/locale.d.ts
@@ -183,5 +183,8 @@ export interface Locale {
     CleanSuccessful: string;
     NoFileToClean: string;
     SettingsReset: string;
+
+    UnexpectedErrorOccurred: string;
+    FailedToParseCanvas: string;
   };
 }

--- a/src/locales/locale.d.ts
+++ b/src/locales/locale.d.ts
@@ -15,6 +15,17 @@ export interface Locale {
         Label: string;
         Description: string;
       };
+
+      Notifications: {
+        Label: string;
+        Description: string;
+
+        Options: {
+          ShowAllNotifications: string;
+          ShowOnlyErrors: string;
+          HideAll: string;
+        };
+      };
     };
 
     Folders: {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -161,6 +161,11 @@ export class FileCleanerSettingTab extends PluginSettingTab {
               .ShowAllNotifications,
           )
           .addOption(
+            Notification.ShowOnlyErrors,
+            translate().Settings.RegularOptions.Notifications.Options
+              .ShowOnlyErrors,
+          )
+          .addOption(
             Notification.HideAll,
             translate().Settings.RegularOptions.Notifications.Options.HideAll,
           )

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,13 +1,14 @@
 import { App, Notice, PluginSettingTab, Setting } from "obsidian";
 import FileCleanerPlugin from ".";
 import translate from "./i18n";
-import { Deletion } from "./enums";
+import { Deletion, Notification } from "./enums";
 import { ResetSettingsModal } from "./modals";
 import { userHasPlugin } from "./helpers/helpers";
 
 export interface FileCleanerSettings {
   deletionDestination: Deletion;
   obsidianTrashCleanupAge: number;
+  notifications: Notification;
   excludeInclude: ExcludeInclude;
   excludedFolders: string[];
   attachmentsExcludeInclude: ExcludeInclude;
@@ -38,6 +39,7 @@ export enum ExcludeInclude {
 export const DEFAULT_SETTINGS: FileCleanerSettings = {
   deletionDestination: Deletion.SystemTrash,
   obsidianTrashCleanupAge: -1,
+  notifications: Notification.ShowAll,
   excludeInclude: ExcludeInclude.Exclude,
   excludedFolders: [],
   attachmentsExcludeInclude: ExcludeInclude.Include,
@@ -145,6 +147,30 @@ export class FileCleanerSettingTab extends PluginSettingTab {
             this.plugin.saveSettings();
           });
         });
+    // #endregion
+
+    // #region Notifications
+    new Setting(containerEl)
+      .setName(translate().Settings.RegularOptions.Notifications.Label)
+      .setDesc(translate().Settings.RegularOptions.Notifications.Description)
+      .addDropdown((dropdown) =>
+        dropdown
+          .addOption(
+            Notification.ShowAll,
+            translate().Settings.RegularOptions.Notifications.Options
+              .ShowAllNotifications,
+          )
+          .addOption(
+            Notification.HideAll,
+            translate().Settings.RegularOptions.Notifications.Options.HideAll,
+          )
+          .setValue(this.plugin.settings.notifications)
+          .onChange((value) => {
+            this.plugin.settings.notifications = value as Notification;
+            this.plugin.saveSettings();
+            this.display();
+          }),
+      );
     // #endregion
 
     // #region Folder inclusion / exclusion

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,7 +3,7 @@ import FileCleanerPlugin from ".";
 import translate from "./i18n";
 import { Deletion, Notification } from "./enums";
 import { ResetSettingsModal } from "./modals";
-import { userHasPlugin } from "./helpers/helpers";
+import { notify, userHasPlugin } from "./helpers/helpers";
 
 export interface FileCleanerSettings {
   deletionDestination: Deletion;
@@ -575,7 +575,7 @@ export class FileCleanerSettingTab extends PluginSettingTab {
                 this.display();
                 this.plugin.loadSettings();
 
-                new Notice(translate().Notifications.SettingsReset);
+                notify(translate().Notifications.SettingsReset);
               },
             });
           });

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,10 +1,11 @@
-import { App, Notice, TAbstractFile, TFile, TFolder } from "obsidian";
+import { App, TAbstractFile, TFile, TFolder } from "obsidian";
 import { ExcludeInclude, type FileCleanerSettings } from "./settings";
 import {
   getExtensions,
   getFilesInFolder,
   getInUseAttachments,
   getSubFoldersInFolder,
+  notify,
   removeFiles,
   userHasPlugin,
 } from "./helpers/helpers";
@@ -206,7 +207,7 @@ export async function runCleanup(
   filesAndFolders.push(...foldersToRemove.reverse());
 
   if (filesAndFolders.length === 0)
-    new Notice(translate().Notifications.NoFileToClean);
+    notify(translate().Notifications.NoFileToClean);
   else {
     if (!settings.deletionConfirmation)
       await removeFiles(filesAndFolders, app, settings);


### PR DESCRIPTION
This PR adds a configuration option to adjust the notification messages.
The options are **Show all**, **Show only errors**, **Hide all** (Defaults to **Show all**)

Currently only the canvas helper has an explicit error notification, however any issues that could occur during the cleanup process, will report an error with the message `An unexpected error occurred, please check the console`.

<img width="1120" height="401" alt="image" src="https://github.com/user-attachments/assets/2fb81cd2-e168-4f53-b4a5-6ad73368665b" />
