### PR TITLE
Add option enable debug logging

### DIFF
--- a/src/helpers/codeblock.ts
+++ b/src/helpers/codeblock.ts
@@ -1,4 +1,5 @@
 import { App, TFile } from "obsidian";
+import { logGroupEnd, logGroupStart, logMsg } from "./logging";
 
 export async function getCodeblockAttachments(
   app: App,
@@ -6,7 +7,7 @@ export async function getCodeblockAttachments(
 ) {
   if (!languageFilter) return [];
 
-  console.group("Codeblock attachments");
+  logGroupStart("Codeblock attachments");
   const indexingStart = Date.now();
 
   const files = await getCodeblocksFromMarkdownFiles(app);
@@ -38,10 +39,10 @@ export async function getCodeblockAttachments(
   });
 
   const duration = (Date.now() - indexingStart) / 1000;
-  console.log(
+  logMsg(
     `Found ${attachments.length} attachments in codeblocks in ${duration}ms.`,
   );
-  console.groupEnd();
+  logGroupEnd();
 
   return attachments.flatMap((attachment) => [...attachment]);
 }

--- a/src/helpers/extras/admonition.ts
+++ b/src/helpers/extras/admonition.ts
@@ -1,7 +1,8 @@
 import { App } from "obsidian";
+import { logGroupEnd, logGroupStart, logMsg } from "../logging";
 
 export async function getAdmonitionAttachments(app: App) {
-  console.group("Admonition");
+  logGroupStart("Admonition");
   const indexingStart = Date.now();
 
   const attachments: string[] = [];
@@ -24,9 +25,7 @@ export async function getAdmonitionAttachments(app: App) {
       ),
   );
 
-  console.log(
-    `Iterating over ${admonitionCandidates.length} files with codeblocks`,
-  );
+  logMsg(`Iterating over ${admonitionCandidates.length} files with codeblocks`);
   for (const { file, cache } of admonitionCandidates) {
     const content = await app.vault.cachedRead(file);
 
@@ -56,9 +55,9 @@ export async function getAdmonitionAttachments(app: App) {
     }
   }
   const duration = (Date.now() - indexingStart) / 1000;
-  console.log(
+  logMsg(
     `Found ${attachments.length} attachments in Admonition blocks in ${duration}ms.`,
   );
-  console.groupEnd();
+  logGroupEnd();
   return attachments;
 }

--- a/src/helpers/extras/ink.ts
+++ b/src/helpers/extras/ink.ts
@@ -1,5 +1,6 @@
 import { App } from "obsidian";
 import { getCodeblocksFromMarkdownFiles } from "../codeblock";
+import { logGroupEnd, logGroupStart, logMsg } from "../logging";
 
 type HandDrawnFile = {
   versionAtEmbed: string;
@@ -14,7 +15,7 @@ type HandWrittenFile = {
 type InkFile = HandDrawnFile | HandWrittenFile;
 
 export async function getInkAttachments(app: App) {
-  console.group("Ink");
+  logGroupStart("Ink");
   const indexingStart = Date.now();
 
   const files = await getCodeblocksFromMarkdownFiles(app);
@@ -32,9 +33,9 @@ export async function getInkAttachments(app: App) {
   });
 
   const duration = (Date.now() - indexingStart) / 1000;
-  console.log(
+  logMsg(
     `Found ${attachments.length} attachments in Ink blocks in ${duration}ms.`,
   );
-  console.groupEnd();
+  logGroupEnd();
   return attachments;
 }

--- a/src/helpers/logging.ts
+++ b/src/helpers/logging.ts
@@ -1,0 +1,19 @@
+import { getSettings } from "./helpers";
+
+export function logMsg(msg: string) {
+  const settings = getSettings();
+
+  if (settings.debugLogging) console.log(msg);
+}
+
+export function logGroupStart(name?: string) {
+  const settings = getSettings();
+
+  if (settings.debugLogging) console.group(name);
+}
+
+export function logGroupEnd() {
+  const settings = getSettings();
+
+  if (settings.debugLogging) console.groupEnd();
+}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -154,6 +154,11 @@ const enUS: Locale = {
         Label: "Run on startup",
         Description: "Runs the cleaner on startup",
       },
+
+      DebugLogging: {
+        Label: "Enable debug logging",
+        Description: "Whether debug logging should be enabled",
+      },
     },
 
     ExternalPluginSupport: {

--- a/src/locales/locale.d.ts
+++ b/src/locales/locale.d.ts
@@ -130,6 +130,11 @@ export interface Locale {
         Label: string;
         Description: string;
       };
+
+      DebugLogging: {
+        Label: string;
+        Description: string;
+      };
     };
 
     ExternalPluginSupport: {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -24,6 +24,7 @@ export interface FileCleanerSettings {
   fileAgeThreshold: number;
   closeNewTabs: boolean;
   deleteEmptyFileOnClose: boolean;
+  debugLogging: boolean;
 
   ExternalPlugins: {
     Excalidraw: {
@@ -55,6 +56,7 @@ export const DEFAULT_SETTINGS: FileCleanerSettings = {
   fileAgeThreshold: 0,
   closeNewTabs: false,
   deleteEmptyFileOnClose: false,
+  debugLogging: false,
 
   ExternalPlugins: {
     Excalidraw: {
@@ -515,6 +517,19 @@ export class FileCleanerSettingTab extends PluginSettingTab {
         toggle.onChange((value) => {
           this.plugin.settings.runOnStartup = value;
           this.plugin.saveSettings();
+        });
+      });
+    // #endregion
+    // #region Run on startup
+    new Setting(containerEl)
+      .setName(translate().Settings.Other.DebugLogging.Label)
+      .setDesc(translate().Settings.Other.DebugLogging.Description)
+      .addToggle((toggle) => {
+        toggle.setValue(this.plugin.settings.debugLogging);
+
+        toggle.onChange(async (value) => {
+          this.plugin.settings.debugLogging = value;
+          await this.plugin.saveSettings();
         });
       });
     // #endregion

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,6 +19,7 @@ import { Deletion } from "./enums";
 import { checkExcalidraw } from "./helpers/extras/excalidraw";
 import { getCodeblockAttachments } from "./helpers/codeblock";
 import { getInkAttachments } from "./helpers/extras/ink";
+import { logGroupEnd, logGroupStart, logMsg } from "./helpers/logging";
 
 async function checkFile(
   app: App,
@@ -83,7 +84,7 @@ async function cleanTrashFolder(app: App, settings: FileCleanerSettings) {
     date.getDate() - settings.obsidianTrashCleanupAge,
   );
 
-  console.group("Checking '.trash' folder");
+  logGroupStart("Checking '.trash' folder");
   const trashDirectory = await app.vault.adapter.list(".trash");
   for (const file of trashDirectory.files) {
     const f = await app.vault.adapter.stat(file);
@@ -101,13 +102,13 @@ async function cleanTrashFolder(app: App, settings: FileCleanerSettings) {
       console.debug("Removed folder:", folder);
     }
   }
-  console.groupEnd();
+  logGroupEnd();
 }
 
 export async function scanVault(app: App, settings: FileCleanerSettings) {
   const indexingStart = Date.now();
-  console.group("File Cleaner Redux");
-  console.log(`Starting cleanup`);
+  logGroupStart("File Cleaner Redux");
+  logMsg(`Starting cleanup`);
 
   // Attachments which are linked to according to Obsidian
   const inUseAttachmentsInitial = getInUseAttachments(app);
@@ -186,8 +187,8 @@ export async function scanVault(app: App, settings: FileCleanerSettings) {
   });
 
   const indexingDuration = (Date.now() - indexingStart) / 1000;
-  console.log(`Finished indexing after ${indexingDuration}ms`);
-  console.log(
+  logMsg(`Finished indexing after ${indexingDuration}ms`);
+  logMsg(
     `Found ${filesToRemove.length} files and ${foldersToRemove.length} folders to clean up.`,
   );
 
@@ -219,13 +220,13 @@ export async function runCleanup(
       });
     }
 
-    console.group("Files:");
+    logGroupStart("Files:");
     filesToRemove.forEach((item) => console.debug(item.path));
-    console.groupEnd();
+    logGroupEnd();
 
-    console.group("Folders:");
+    logGroupStart("Folders:");
     foldersToRemove.forEach((item) => console.debug(item.path));
-    console.groupEnd();
+    logGroupEnd();
   }
 
   if (settings.deletionDestination === Deletion.ObsidianTrash)
@@ -233,5 +234,5 @@ export async function runCleanup(
 
   if (settings.closeNewTabs) app.workspace.detachLeavesOfType("empty");
 
-  console.groupEnd();
+  logGroupEnd();
 }


### PR DESCRIPTION
Adds an option to enable debug logging in the console under the Other section (default false).

<img width="743" height="104" alt="image" src="https://github.com/user-attachments/assets/4c695f3b-deda-45f9-8966-aa030a70c322" />


This reduces the amount of warnings from the community scanner as it now gates it behind a single setting.
Once enabled, all the regular logging messages will be shown in the Developer Console.