### PR TITLE
Ignore empty exclusion list

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -71,7 +71,7 @@ const enUS: Locale = {
         Excluded: {
           Label: "Excluded attachment extensions",
           Description:
-            "List of extensions that should be ignored during cleanup, all other files are included, the `.*` wildcard can be used to select all extensions. Comma-separated.<br /><p>Notice: If the list is empty, <b>all files</b> will be targeted!</p>",
+            "List of extensions that should be ignored during cleanup, all other files are included, the `.*` wildcard can be used to select all extensions. Comma-separated.",
           Placeholder: "Example:.jpg, .png, .pdf, .*",
         },
         Included: {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -308,11 +308,6 @@ export class FileCleanerSettingTab extends PluginSettingTab {
           maxHeight: "8rem",
         });
       });
-    attachmentExcludeIncludeSetting.descEl.setHTMLUnsafe(
-      this.plugin.settings.attachmentsExcludeInclude
-        ? translate().Settings.Files.Attachments.Included.Description
-        : translate().Settings.Files.Attachments.Excluded.Description,
-    );
     // #endregion
 
     // #region File age threshold

--- a/src/util.ts
+++ b/src/util.ts
@@ -46,6 +46,10 @@ async function checkFile(
     return await checkCanvas(file, app);
   }
 
+  // Exclude all files if exclusion list is not populated.
+  if (settings.attachmentsExcludeInclude === ExcludeInclude.Exclude)
+    extensions.push(".*");
+
   const extensionsRegex = RegExp(`^(${["md", ...extensions].join("|")})$`);
   if (settings.attachmentsExcludeInclude === ExcludeInclude.Include) {
     return file.extension.match(extensionsRegex);


### PR DESCRIPTION
This PR makes it so that all attachments are ignored if the Exclusion list is empty.

The user will now need to explicitly use the Include list and set it to include all using the regular expression `.*`.

This removes the call to `setHTMLUnsafe`

Fixes #162 