### PR TITLE
fix(i18n): fallback to `en` when no matching locale is found

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -14,5 +14,8 @@ const LOCALES: LOCALE = {
 export default function translate() {
   const systemLocale = moment.locale();
 
-  return LOCALES[systemLocale];
+  const locale = LOCALES[systemLocale];
+
+  if (locale !== undefined) return locale;
+  else return LOCALES["en"];
 }


### PR DESCRIPTION
On Mac and Windows versions of Obsidian the bundled version of `moment.locale` returns more granularity like `en-us` / `en-gb` etc.
On Linux (for now) it only returns `en`.

This PR makes it so that it falls back to using `en` if no matching locale is found.
