### PR TITLE
Update Exclude/Include settings to make them more understandable

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -47,7 +47,8 @@ const enUS: Locale = {
           Folders that should be excluded during cleanup, all other folders will be scanned.
           Paths are case-sensitive.
           One folder per line.
-          Supports regular expressions (wildcard matching can be done using \`.*\`)`,
+          Supports regular expressions (wildcard matching can be done using \`.*\`)
+          Ignored if empty.`,
         },
         Included: {
           Label: "Included folders",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -71,7 +71,7 @@ const enUS: Locale = {
         Excluded: {
           Label: "Excluded attachment extensions",
           Description:
-            "List of extensions that should be ignored during cleanup, all other files are included, the `.*` wildcard can be used to select all extensions. Comma-separated.",
+            "List of extensions that should be ignored during cleanup, all other files are included, the `.*` wildcard can be used to select all extensions. Comma-separated. Ignored if empty.",
           Placeholder: "Example:.jpg, .png, .pdf, .*",
         },
         Included: {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -57,10 +57,10 @@ const enUS: Locale = {
           One folder per line.
           Supports regular expressions (wildcard matching can be done using \`.*\`)`,
         },
-        Label: "Excluded / Included folders",
+        Label: "Folder filtering",
         Placeholder: "Example:\nfolder/subfolder\nfolder2/subfolder2",
         Description:
-          "The folders below should be excluded from or included in the cleanup process.",
+          "Wether the folders listed below should be excluded or included during cleanup",
       },
     },
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -80,9 +80,9 @@ const enUS: Locale = {
             "List of extensions that should be included during cleanup, all other files are ignored, the `.*` wildcard can be used to select all extensions. Comma-separated.",
           Placeholder: "Example:.jpg, .png, .pdf, .*",
         },
-        Label: "Excluded / Included extensions",
+        Label: "Attachment extension filtering",
         Description:
-          "The attachment extensions below should be excluded from or included in the cleanup process.",
+          "Wether the extensions listed below should be excluded or included during cleanup",
       },
 
       FileAgeThreshold: {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -204,10 +204,13 @@ export class FileCleanerSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName(translate().Settings.Folders.FolderFiltering.Label)
       .setDesc(translate().Settings.Folders.FolderFiltering.Description)
-      .addToggle((toggle) => {
-        toggle.setValue(Boolean(this.plugin.settings.excludeInclude));
+      .addDropdown((component) => {
+        component.addOption("0", "Excluded");
+        component.addOption("1", "Included");
 
-        toggle.onChange(async (value) => {
+        component.setValue(String(this.plugin.settings.excludeInclude));
+
+        component.onChange(async (value: string) => {
           this.plugin.settings.excludeInclude = Number(value);
           await this.plugin.saveSettings();
           this.display();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -259,12 +259,15 @@ export class FileCleanerSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName(translate().Settings.Files.Attachments.Label)
       .setDesc(translate().Settings.Files.Attachments.Description)
-      .addToggle((toggle) => {
-        toggle.setValue(
-          Boolean(this.plugin.settings.attachmentsExcludeInclude),
+      .addDropdown((component) => {
+        component.addOption("0", "Excluded");
+        component.addOption("1", "Included");
+
+        component.setValue(
+          String(this.plugin.settings.attachmentsExcludeInclude),
         );
 
-        toggle.onChange(async (value) => {
+        component.onChange(async (value: string) => {
           this.plugin.settings.attachmentsExcludeInclude = Number(value);
           await this.plugin.saveSettings();
           this.display();


### PR DESCRIPTION
This PR changes the **Excluded/Included** settings to be dropdown instead off toggle.
It also updates the labels and descriptions for both folders and extensions.

There is still work to be done to make these settings easier to use.

### Folder filtering
<img width="777" height="319" alt="image" src="https://github.com/user-attachments/assets/659ff39a-1544-434e-b4b0-330add2a9511" />



### Attachment extension filtering
<img width="780" height="284" alt="image" src="https://github.com/user-attachments/assets/e43be159-b20e-4c0d-8260-0309afa5db0f" />



- **fix(i18n): update description for "Excluded attachment extensions" to inform about being ignored if empty**
- **fix(i18n): Renamed label and description for "Excluded / Included folders", no named "Folder filtering"**
- **fix(i18n): Renamed label and description for "Excluded / Included extensions", no named "Extension filtering"**
- **fix(settings): replaced Folder filtering toggle with dropdown listing the values explicitly**
- **fix(settings): replaced Extension filtering toggle with dropdown listing the values explicitly**
- **fix(i18n): update description for "Excluded folders" to inform about being ignored if empty**
